### PR TITLE
Use messageIdentifier as sequenceIdentifier

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.11.0</version>
                 <executions>
                     <execution>
                         <id>install node and yarn</id>

--- a/starter/src/main/java/com/insidion/axon/openadmin/dlq/DlqActionEndpoint.kt
+++ b/starter/src/main/java/com/insidion/axon/openadmin/dlq/DlqActionEndpoint.kt
@@ -30,7 +30,7 @@ class DlqActionEndpoint(
             val list = it.toList()
             val i = list.first()
             val firstMessage = i.message()
-            val sequence = sequencingPolicy.getSequenceIdentifierFor(firstMessage).toString()
+            val sequence = sequencingPolicy.getSequenceIdentifierFor(firstMessage)?.toString() ?: i.message().identifier
             DlqItem(
                 sequence,
                 list.size,


### PR DESCRIPTION
If the sequencingPolicy does not return a sequenceIdentifier, the messageIdentifier is used (just like in `DeadLetteringEventHandlerInvoker`)